### PR TITLE
Document exact versions of deps (& sub-deps)

### DIFF
--- a/example/swarm.js
+++ b/example/swarm.js
@@ -1,8 +1,9 @@
 var createGame = require('voxel-engine');
 var voxel = require('voxel');
+var texturePath = require('painterly-textures')(__dirname)
 var game = createGame({
     generate: voxel.generator['Valley'],
-    texturePath: '/textures/'
+    texturePath: texturePath
 });
 game.appendTo('#container');
 

--- a/package.json
+++ b/package.json
@@ -4,14 +4,22 @@
     "description": "blocky spider creatures for your voxel.js game",
     "main": "index.js",
     "dependencies": {
-        "voxel-texture": "~0.3.1",
-        "voxel-physical": "~0.0.2",
-        "voxel-creature": "~0.1.0"
+        "voxel-texture": "0.3.1",
+        "voxel-physical": "0.0.2",
+        "voxel-creature": "0.1.0"
     },
     "devDependencies": {
-        "voxel-player": "~0.0.0",
-        "voxel-engine": "~0.0.0",
-        "painterly-textures": "~0.0.3"
+        "voxel-player": "0.0.1",
+        "voxel-engine": "0.5.8",
+        "painterly-textures": "0.0.3",
+        "voxel": "0.1.4",
+        "minecraft-skin": "0.0.3",
+        "three": "0.54.0",
+        "browserify": "1.17.3",
+        "beefy": "0.0.11"
+    },
+    "scripts": {
+      "start": "beefy example/swarm.js:bundle.js 8080"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
The 'swarm' demo at http://substack.net/projects/voxel-spider/ had the functionality I was looking for and worked more smoothly than the voxel demo that I had originally used as a starting point.

But when I tried to rebuild it, it literally took me hours to find the exact versions of the dependencies (& sub-dependencies like three.js & minecraft-skin) to make it work. I documented these in this pull request by setting them as devDependencies. With these changes, a `npm install`, followed by `npm start` actually makes the swarm example work.